### PR TITLE
Sanitise user input for computerName

### DIFF
--- a/example_provisioning_script.sh
+++ b/example_provisioning_script.sh
@@ -79,15 +79,18 @@ if [[ "$computerName" == "" ]] || [[ "$computerRole" == "" ]]; then
 	computerRole=$(/usr/libexec/plistbuddy /var/tmp/userinputoutput.txt -c "print 'Computer Role'")
 
         # Sanitise user input for computerName
+        # The next 3 lines will replace all spaces with hypens, drop all chars not a-z or a number or a hypen, then reduce remaining to max 15 chars
         computerName=${computerName// /-}
         computerName=${computerName//[^a-zA-Z0-9_-]/}
         computerName=${computerName::15}
-        computerName=`echo $computerName | tr A-Z a-z`
-        #^- above 4 lines will replace all spaces with hypens, drop all chars not a-z or a number or a hypen, then reduce remaining to max 15 chars, finally it sets to all lowercase
+
+        # If wishing to set everything to lowercase uncomment the next line, if wishing to set uppercase uncomment the second line.
+	#computerName=$(echo "$computerName" | tr '[:upper:]' '[:lower:]')
+        #computerName=$(echo "$computerName" | tr '[:lower:]' '[:upper:]')
 
         if [[ $computerName == "" ]]; then
                 log "Failed computerName sanitisation, defaulting to: $serial"
-                computerName=$serial
+                computerName="$serial"
         else
                 log "Passed computerName sanitisation, proceeding with: $computerName"
         fi

--- a/example_provisioning_script.sh
+++ b/example_provisioning_script.sh
@@ -78,6 +78,20 @@ if [[ "$computerName" == "" ]] || [[ "$computerRole" == "" ]]; then
 	computerName=$(/usr/libexec/plistbuddy /var/tmp/userinputoutput.txt -c "print 'Computer Name'")
 	computerRole=$(/usr/libexec/plistbuddy /var/tmp/userinputoutput.txt -c "print 'Computer Role'")
 
+        # Sanitise user input for computerName
+        computerName=${computerName// /-}
+        computerName=${computerName//[^a-zA-Z0-9_-]/}
+        computerName=${computerName::15}
+        computerName=`echo $computerName | tr A-Z a-z`
+        #^- above 4 lines will replace all spaces with hypens, drop all chars not a-z or a number or a hypen, then reduce remaining to max 15 chars, finally it sets to all lowercase
+
+        if [[ $computerName == "" ]]; then
+                log "Failed computerName sanitisation, defaulting to: $serial"
+                computerName=$serial
+        else
+                log "Passed computerName sanitisation, proceeding with: $computerName"
+        fi
+
 	# Update Hostname and Computer Role in JSS
 	# Create xml
 	/bin/cat << EOF > /var/tmp/name.xml


### PR DESCRIPTION
Added code will do the following to the computerName value provided by the user:

- replace all spaces with hypens
- drop all chars not a-z or a number or a hypen
- reduce remaining to max 15 chars
- sets to all lowercase

Should this code reduce the value to nothing, it will reset the computerName value to be the serial number.

Otherwise it will proceed with the value after sanitisation.

n.b  I haven't tested this code yet, just a copy and paste from my script with the variable names changed back. 

Also, this will default to a computer name which is simply the serial number of the computer if the user input is blank. I've seen these sorts of set name scripts do something like set a $prefix variable and then the computerName variable could become "$prefix-$serial".